### PR TITLE
Support clone pools and claim command (zpeedap)

### DIFF
--- a/client.go
+++ b/client.go
@@ -123,6 +123,22 @@ func (c Client) CloneSnap(resource string, snap time.Time, claimArgs ClaimArgs) 
 	return &clone, err
 }
 
+func (c Client) ExpireClaim(resource string, claimId string) error {
+	uri := strings.TrimRight(fmt.Sprintf("http://%s/resources/%s/claims/%s", c.server, resource, claimId), "/")
+	req, err := c.newReq("DELETE", uri, nil)
+	if err != nil {
+		return err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return fmt.Errorf("did not get status code 200, got %d", res.StatusCode)
+	}
+	return nil
+}
+
 func (c Client) DestroyClone(resource string, clone time.Time) error {
 	var cloneStr string
 	if !clone.IsZero() {

--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ type Client struct {
 
 type ClaimArgs struct {
 	ClaimPooled bool
-	Ttl         int64
+	TtlSeconds  int64
 }
 
 func NewClient(user, server string) *Client {
@@ -99,9 +99,9 @@ func (c Client) CloneSnap(resource string, snap time.Time, claimArgs ClaimArgs) 
 	if err != nil {
 		return nil, err
 	}
-	if claimArgs.ClaimPooled && claimArgs.Ttl != 0 {
+	if claimArgs.ClaimPooled && claimArgs.TtlSeconds != 0 {
 		q := req.URL.Query()
-		q.Add("ttl", strconv.FormatInt(claimArgs.Ttl, 10))
+		q.Add("ttl", strconv.FormatInt(claimArgs.TtlSeconds, 10))
 		req.URL.RawQuery = q.Encode()
 	}
 	res, err := http.DefaultClient.Do(req)

--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package zdap
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/modfin/zdap/cmd/zdap/commands"
 	"github.com/modfin/zdap/internal/utils"
 	"io"
 	"io/ioutil"
@@ -16,6 +15,11 @@ import (
 type Client struct {
 	user   string
 	server string
+}
+
+type ClaimArgs struct {
+	ClaimPooled bool
+	Ttl         int64
 }
 
 func NewClient(user, server string) *Client {
@@ -82,7 +86,7 @@ func (c Client) GetResources() ([]PublicResource, error) {
 	return resources, err
 }
 
-func (c Client) CloneSnap(resource string, snap time.Time, claimArgs commands.ClaimArgs) (*PublicClone, error) {
+func (c Client) CloneSnap(resource string, snap time.Time, claimArgs ClaimArgs) (*PublicClone, error) {
 	var snapStr string
 	if !snap.IsZero() {
 		snapStr = snap.Format(utils.TimestampFormat)

--- a/client.go
+++ b/client.go
@@ -100,7 +100,9 @@ func (c Client) CloneSnap(resource string, snap time.Time, claimArgs ClaimArgs) 
 		return nil, err
 	}
 	if claimArgs.ClaimPooled && claimArgs.Ttl != 0 {
-		req.Form.Add("ttl", strconv.FormatInt(claimArgs.Ttl, 10))
+		q := req.URL.Query()
+		q.Add("ttl", strconv.FormatInt(claimArgs.Ttl, 10))
+		req.URL.RawQuery = q.Encode()
 	}
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -93,7 +93,7 @@ func (c Client) CloneSnap(resource string, snap time.Time, claimArgs ClaimArgs) 
 	}
 	uri := strings.TrimRight(fmt.Sprintf("http://%s/resources/%s/snaps/%s", c.server, resource, snapStr), "/")
 	if claimArgs.ClaimPooled {
-		uri = strings.TrimRight(fmt.Sprintf("http://%s/resources/%s/claim", c.server, resource), "/")
+		uri = fmt.Sprintf("http://%s/resources/%s/claim", c.server, resource)
 	}
 	req, err := c.newReq("POST", uri, nil)
 	if err != nil {

--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -186,7 +186,7 @@ func ClaimResource(c *cli.Context) error {
 	ttl := c.Int64("ttl")
 	clone, err := cloneResource(c.Args().Slice(), zdap.ClaimArgs{
 		ClaimPooled: true,
-		Ttl:         ttl,
+		TtlSeconds:  ttl,
 	})
 	if err != nil {
 		return err
@@ -388,7 +388,7 @@ func AttachClone(c *cli.Context) error {
 		fmt.Print("Cloning ", resource, "...")
 		clone, err = cloneResource(c.Args().Slice(), zdap.ClaimArgs{
 			ClaimPooled: c.Bool("claim"),
-			Ttl:         c.Int64("ttl"),
+			TtlSeconds:  c.Int64("ttl"),
 		})
 		if err != nil {
 			return err

--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -150,6 +150,39 @@ type ClaimResult struct {
 	CloneId string `json:"clone_id"`
 }
 
+func ExpireClaimedResource(c *cli.Context) error {
+	args := c.Args().Slice()
+	if len(args) < 2 {
+		return errors.New("no claim specified")
+	}
+
+	resource := args[0]
+	claimId := args[1]
+
+	fmt.Println("destroying")
+	var err error
+
+	cfg, err := getConfig()
+	if err != nil {
+		return err
+	}
+
+	servers := cfg.Servers
+
+	for _, s := range servers {
+		client := zdap.NewClient(cfg.User, s)
+		err = client.ExpireClaim(resource, claimId)
+		if err != nil {
+			fmt.Println("[Err]", err)
+			err = nil
+			continue
+		}
+	}
+
+	return nil
+
+}
+
 func ClaimResource(c *cli.Context) error {
 	ttl := c.Int64("ttl")
 	clone, err := cloneResource(c.Args().Slice(), zdap.ClaimArgs{

--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -159,7 +159,6 @@ func ExpireClaimedResource(c *cli.Context) error {
 	resource := args[0]
 	claimId := args[1]
 
-	fmt.Println("destroying")
 	var err error
 
 	cfg, err := getConfig()

--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -140,7 +140,7 @@ func CloneResource(c *cli.Context) error {
 		return err
 	}
 	fmt.Println("Attach to project by running, run:")
-	fmt.Printf("zdap attach @%s %s %s\n", clone.Server, clone.Resource, clone.CreatedAt.Format(utils.TimestampFormat))
+	fmt.Printf("zdap attach --new=false @%s:%d %s %s\n", clone.Server, clone.Port, clone.Resource, clone.CreatedAt.Format(utils.TimestampFormat))
 	return nil
 }
 
@@ -199,8 +199,6 @@ func ClaimResource(c *cli.Context) error {
 	})
 
 	fmt.Println(string(b))
-	fmt.Println("Attach to project by running, run:")
-	fmt.Printf("zdap attach @%s %s %s\n", clone.Server, clone.Resource, clone.CreatedAt.Format(utils.TimestampFormat))
 	return nil
 }
 

--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -62,9 +62,9 @@ func findServerCandidate(resource string, user string, servers []string, favorPo
 		load := stat.Load15
 
 		sum := math.Log2(float64(disk) / float64(datasize.GB) / 100.0) // more disk is good
-		sum += math.Log2(float64(mem) / float64(datasize.GB))          // mode ram is good
+		sum += math.Log2(float64(mem) / float64(datasize.GB))          // more ram is good
 		if clones > 0 {
-			sum -= math.Log2(float64(clones)) // less clones is good
+			sum -= math.Log2(float64(clones)) // fewer clones is good
 		}
 		if load > 0 {
 			sum -= math.Log2(load) // load less than 1 is good

--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -158,6 +158,12 @@ func ExpireClaimedResource(c *cli.Context) error {
 
 	resource := args[0]
 	claimId := args[1]
+	var server *string
+	if strings.Contains(claimId, "@") {
+		splitStrings := strings.Split(claimId, "@")
+		server = &splitStrings[0]
+		claimId = splitStrings[1]
+	}
 
 	var err error
 
@@ -165,8 +171,12 @@ func ExpireClaimedResource(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-
-	servers := cfg.Servers
+	var servers []string
+	if server != nil {
+		servers = []string{*server}
+	} else {
+		servers = cfg.Servers
+	}
 
 	for _, s := range servers {
 		client := zdap.NewClient(cfg.User, s)
@@ -194,7 +204,7 @@ func ClaimResource(c *cli.Context) error {
 	b, err := json.Marshal(ClaimResult{
 		Server:  clone.Server,
 		Port:    clone.Port,
-		CloneId: clone.Name,
+		CloneId: fmt.Sprintf("%s:%d@%s", clone.Server, clone.APIPort, clone.Name),
 	})
 
 	fmt.Println(string(b))

--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -135,7 +135,7 @@ func CloneResourceCompletion(c *cli.Context) {
 }
 
 func CloneResource(c *cli.Context) error {
-	clone, err := cloneResource(c.Args().Slice(), ClaimArgs{})
+	clone, err := cloneResource(c.Args().Slice(), zdap.ClaimArgs{})
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ type ClaimResult struct {
 
 func ClaimResource(c *cli.Context) error {
 	ttl := c.Int64("ttl")
-	clone, err := cloneResource(c.Args().Slice(), ClaimArgs{
+	clone, err := cloneResource(c.Args().Slice(), zdap.ClaimArgs{
 		ClaimPooled: true,
 		Ttl:         ttl,
 	})
@@ -171,12 +171,7 @@ func ClaimResource(c *cli.Context) error {
 	return nil
 }
 
-type ClaimArgs struct {
-	ClaimPooled bool
-	Ttl         int64
-}
-
-func cloneResource(args []string, claimArgs ClaimArgs) (*zdap.PublicClone, error) {
+func cloneResource(args []string, claimArgs zdap.ClaimArgs) (*zdap.PublicClone, error) {
 	var err error
 
 	cfg, err := getConfig()
@@ -361,7 +356,7 @@ func AttachClone(c *cli.Context) error {
 
 	if c.Bool("new") {
 		fmt.Print("Cloning ", resource, "...")
-		clone, err = cloneResource(c.Args().Slice(), ClaimArgs{
+		clone, err = cloneResource(c.Args().Slice(), zdap.ClaimArgs{
 			ClaimPooled: c.Bool("claim"),
 			Ttl:         c.Int64("ttl"),
 		})

--- a/cmd/zdap/commands/helpers.go
+++ b/cmd/zdap/commands/helpers.go
@@ -11,15 +11,19 @@ import (
 )
 
 func ensureConfig() (string, error) {
-	dirname, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
+	conffile := os.Getenv("ZDAP_CONF")
+	if conffile == "" {
+		dirname, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		err = os.MkdirAll(filepath.Join(dirname, ".zdap"), 755)
+		if err != nil {
+			return "", err
+		}
+		conffile = filepath.Join(dirname, ".zdap", "zdap-config")
 	}
-	err = os.MkdirAll(filepath.Join(dirname, ".zdap"), 755)
-	if err != nil{
-		return "", err
-	}
-	conffile := filepath.Join(dirname, ".zdap", "zdap-config")
+
 	if _, err := os.Stat(conffile); os.IsNotExist(err) {
 		file, err := os.Create(conffile)
 		if err != nil {

--- a/cmd/zdap/commands/list.go
+++ b/cmd/zdap/commands/list.go
@@ -83,7 +83,7 @@ func ListResources(c *cli.Context) error {
 			fmt.Printf("%s %s", r1, resource.Name)
 			if resource.ClonePool.MinClones > 0 {
 				fmt.Printf(
-					"(pool: min_clones=%d, max_clones=%d, max_lease_time=%ds, default_lease_time=%ds)",
+					" (pool: min_clones=%d, max_clones=%d, max_lease_time=%ds, default_lease_time=%ds)",
 					resource.ClonePool.MinClones,
 					resource.ClonePool.MaxClones,
 					resource.ClonePool.ClaimMaxTimeoutSeconds,

--- a/cmd/zdap/commands/list.go
+++ b/cmd/zdap/commands/list.go
@@ -83,10 +83,11 @@ func ListResources(c *cli.Context) error {
 			fmt.Printf("%s %s", r1, resource.Name)
 			if resource.ClonePool.MinClones > 0 {
 				fmt.Printf(
-					"(pool: min_clones=%d, max_clones=%d, max_lease_time=%ds)",
+					"(pool: min_clones=%d, max_clones=%d, max_lease_time=%ds, default_lease_time=%ds)",
 					resource.ClonePool.MinClones,
 					resource.ClonePool.MaxClones,
 					resource.ClonePool.ClaimMaxTimeoutSeconds,
+					resource.ClonePool.DefaultTimeoutSeconds,
 				)
 			}
 			fmt.Printf("\n")

--- a/cmd/zdap/zdap.go
+++ b/cmd/zdap/zdap.go
@@ -146,9 +146,17 @@ func main() {
 			},
 			{
 				Name:         "claim",
-				Usage:        "claim a pooled clone",
+				Usage:        "claim a pooled clone, first line of output is json response",
 				Action:       commands.ClaimResource,
 				BashComplete: commands.CloneResourceCompletion,
+				Flags: []cli.Flag{
+					&cli.Int64Flag{
+						Name:        "ttl",
+						DefaultText: "0",
+						Usage:       "ttl in seconds, uses pool default if set to 0",
+						Value:       0,
+					},
+				},
 			},
 			{
 				Name:         "destroy",

--- a/cmd/zdap/zdap.go
+++ b/cmd/zdap/zdap.go
@@ -159,6 +159,11 @@ func main() {
 				},
 			},
 			{
+				Name:   "expire",
+				Usage:  "expire a pooled clone",
+				Action: commands.ExpireClaimedResource,
+			},
+			{
 				Name:         "destroy",
 				Usage:        "destroys a clone",
 				Action:       commands.DestroyClone,

--- a/cmd/zdapd/zdapd.go
+++ b/cmd/zdapd/zdapd.go
@@ -333,8 +333,7 @@ func destroyContainer(c types.Container, docker *client.Client) error {
 
 	if c.State == "running" {
 		fmt.Println("- Killing", name)
-		//d := time.Millisecond
-		d := 1
+		d := 0
 		err := docker.ContainerStop(context.Background(), c.ID, container.StopOptions{Timeout: &d})
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/labstack/echo/v4 v4.9.0
+	github.com/labstack/gommon v0.3.1
 	github.com/modfin/henry v0.0.0-20230824150253-35f12224ee68
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/robfig/cron/v3 v3.0.1
@@ -28,7 +29,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/kr/pretty v0.2.1 // indirect
-	github.com/labstack/gommon v0.3.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/modfin/zdap
 go 1.20
 
 require (
-	github.com/bicomsystems/go-libzfs v0.3.5
+	github.com/bicomsystems/go-libzfs v0.4.0
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/docker/docker v24.0.7+incompatible
@@ -53,4 +53,4 @@ require (
 	gotest.tools/v3 v3.0.3 // indirect
 )
 
-replace github.com/bicomsystems/go-libzfs => github.com/ubuntu/go-libzfs v0.2.2-0.20220406085817-43edd0b6397a
+//replace github.com/bicomsystems/go-libzfs => github.com/ubuntu/go-libzfs v0.2.2-0.20220406085817-43edd0b6397a

--- a/go.mod
+++ b/go.mod
@@ -52,5 +52,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 )
-
-//replace github.com/bicomsystems/go-libzfs => github.com/ubuntu/go-libzfs v0.2.2-0.20220406085817-43edd0b6397a

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O6j3w=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/bicomsystems/go-libzfs v0.3.5 h1:3zESKnvRtFn0vzYDjqWHiarcRMoWioTu/IdF4QyT8DM=
+github.com/bicomsystems/go-libzfs v0.3.5/go.mod h1:/ABUjxseIy72AxJV8ROgSfeZ5YA8/ZSp1mMzfDKi0Mw=
+github.com/bicomsystems/go-libzfs v0.4.0 h1:rezv5ZTVe31o2MbACEDrTYAeRO4rSHm70DHOTTas/yU=
+github.com/bicomsystems/go-libzfs v0.4.0/go.mod h1:/ABUjxseIy72AxJV8ROgSfeZ5YA8/ZSp1mMzfDKi0Mw=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b h1:6+ZFm0flnudZzdSE0JxlhR2hKnGPcNB35BjQf4RYQDY=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O6j3w=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/bicomsystems/go-libzfs v0.3.5 h1:3zESKnvRtFn0vzYDjqWHiarcRMoWioTu/IdF4QyT8DM=
-github.com/bicomsystems/go-libzfs v0.3.5/go.mod h1:/ABUjxseIy72AxJV8ROgSfeZ5YA8/ZSp1mMzfDKi0Mw=
 github.com/bicomsystems/go-libzfs v0.4.0 h1:rezv5ZTVe31o2MbACEDrTYAeRO4rSHm70DHOTTas/yU=
 github.com/bicomsystems/go-libzfs v0.4.0/go.mod h1:/ABUjxseIy72AxJV8ROgSfeZ5YA8/ZSp1mMzfDKi0Mw=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b h1:6+ZFm0flnudZzdSE0JxlhR2hKnGPcNB35BjQf4RYQDY=
@@ -90,8 +88,6 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
 github.com/tklauser/numcpus v0.4.0/go.mod h1:1+UI3pD8NW14VMwdgJNJ1ESk2UnwhAnz5hMwiKKqXCQ=
-github.com/ubuntu/go-libzfs v0.2.2-0.20220406085817-43edd0b6397a h1:26F4c7XwD8YH25P5eIcCnZKWobb87XIbZH3oBNN5o8M=
-github.com/ubuntu/go-libzfs v0.2.2-0.20220406085817-43edd0b6397a/go.mod h1:/ABUjxseIy72AxJV8ROgSfeZ5YA8/ZSp1mMzfDKi0Mw=
 github.com/urfave/cli/v2 v2.23.2 h1:34bT/FlchakhE5j+PggFYUfiGZBnrNxJRRVB9AQODOo=
 github.com/urfave/cli/v2 v2.23.2/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -225,7 +225,7 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 	e.POST("/resources/:resource/claim", func(c echo.Context) error {
 		resource := c.Param("resource")
 		timeoutStr := c.QueryParam("ttl")
-		timeout := internal.DefaultClaimMaxTimeoutSeconds * time.Second
+		timeout := internal.DefaultClaimTimeoutSeconds * time.Second
 		if timeoutStr != "" {
 			t, err := strconv.ParseInt(timeoutStr, 10, 64)
 			if err == nil {

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -122,27 +122,32 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 	e.DELETE("/resources/:resource/clones/:time", func(c echo.Context) error {
 		dss, err := z.Open()
 		if err != nil {
+			fmt.Println(err.Error())
 			return err
 		}
 		defer dss.Close()
 
 		snaps, err := getSnaps(dss, c.Get("owner").(string), c.Param("resource"), app)
 		if err != nil {
+			fmt.Println(err.Error())
 			return err
 		}
 		at, err := time.Parse(utils.TimestampFormat, c.Param("time"))
 		if err != nil {
+			fmt.Println(err.Error())
 			return err
 		}
 
 		for _, snap := range snaps {
 			for _, clone := range snap.Clones {
 				if clone.CreatedAt.Equal(at) {
+					fmt.Println("equals createdAt")
 					err = app.DestroyClone(dss, clone.Name)
 					return c.NoContent(http.StatusOK)
 				}
 			}
 		}
+		fmt.Println("nothing found")
 		return errors.New("could not find clone to destroy")
 	})
 

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -224,7 +224,7 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 
 	e.POST("/resources/:resource/claim", func(c echo.Context) error {
 		resource := c.Param("resource")
-		timeoutStr := c.QueryParam("timeoutSeconds")
+		timeoutStr := c.QueryParam("ttl")
 		timeout := internal.DefaultClaimMaxTimeoutSeconds * time.Second
 		if timeoutStr != "" {
 			t, err := strconv.ParseInt(timeoutStr, 10, 64)
@@ -235,7 +235,6 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 
 		clone, err := app.ClaimPooledClone(resource, timeout)
 		if err != nil {
-			fmt.Println("error return")
 			fmt.Println(err.Error())
 			return c.JSON(http.StatusInternalServerError, err)
 		}

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -250,6 +250,13 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 		return c.JSON(http.StatusOK, clone)
 	})
 
+	e.DELETE("/resources/:resource/claims/:claimId", func(c echo.Context) error {
+		resource := c.Param("resource")
+		claimId := c.Param("claimId")
+
+		return app.ExpirePooledClone(resource, claimId)
+	})
+
 	fmt.Println("== Loaded Resources ==")
 	for _, r := range app.GetResourcesNames() {
 		fmt.Println(" -", r)

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -121,6 +121,7 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 
 	e.DELETE("/resources/:resource/clones/:time", func(c echo.Context) error {
 		dss, err := z.Open()
+		fmt.Println("opened")
 		if err != nil {
 			fmt.Println(err.Error())
 			return err
@@ -128,11 +129,13 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 		defer dss.Close()
 
 		snaps, err := getSnaps(dss, c.Get("owner").(string), c.Param("resource"), app)
+		fmt.Println("fetched snaps")
 		if err != nil {
 			fmt.Println(err.Error())
 			return err
 		}
 		at, err := time.Parse(utils.TimestampFormat, c.Param("time"))
+		fmt.Printf("parsed time%s", at)
 		if err != nil {
 			fmt.Println(err.Error())
 			return err
@@ -140,6 +143,7 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 
 		for _, snap := range snaps {
 			for _, clone := range snap.Clones {
+				fmt.Println(clone.Name)
 				if clone.CreatedAt.Equal(at) {
 					fmt.Println("equals createdAt")
 					err = app.DestroyClone(dss, clone.Name)

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -233,7 +233,7 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 			}
 		}
 
-		clone, err := app.ClaimPooledClone(resource, timeout)
+		clone, err := app.ClaimPooledClone(resource, timeout, c.Get("owner").(string))
 		if err != nil {
 			fmt.Println(err.Error())
 			return c.JSON(http.StatusInternalServerError, err)

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -223,8 +223,6 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 	})
 
 	e.POST("/resources/:resource/claim", func(c echo.Context) error {
-		fmt.Println("Reached endpoint ******************'")
-
 		resource := c.Param("resource")
 		timeoutStr := c.QueryParam("timeoutSeconds")
 		timeout := internal.DefaultClaimMaxTimeoutSeconds * time.Second

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -121,37 +121,28 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 
 	e.DELETE("/resources/:resource/clones/:time", func(c echo.Context) error {
 		dss, err := z.Open()
-		fmt.Println("opened")
 		if err != nil {
-			fmt.Println(err.Error())
 			return err
 		}
 		defer dss.Close()
 
 		snaps, err := getSnaps(dss, c.Get("owner").(string), c.Param("resource"), app)
-		fmt.Println("fetched snaps")
 		if err != nil {
-			fmt.Println(err.Error())
 			return err
 		}
 		at, err := time.Parse(utils.TimestampFormat, c.Param("time"))
-		fmt.Printf("parsed time%s", at)
 		if err != nil {
-			fmt.Println(err.Error())
 			return err
 		}
 
 		for _, snap := range snaps {
 			for _, clone := range snap.Clones {
-				fmt.Println(clone.Name)
 				if clone.CreatedAt.Equal(at) {
-					fmt.Println("equals createdAt")
 					err = app.DestroyClone(dss, clone.Name)
 					return c.NoContent(http.StatusOK)
 				}
 			}
 		}
-		fmt.Println("nothing found")
 		return errors.New("could not find clone to destroy")
 	})
 

--- a/internal/bases/bases.go
+++ b/internal/bases/bases.go
@@ -18,7 +18,7 @@ import (
 	"time"
 )
 
-var baseCreationMutex = sync.Mutex{}
+var baseCreationMutex sync.Mutex
 
 func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client.Client, z *zfs.ZFS) error {
 	baseCreationMutex.Lock()
@@ -101,8 +101,7 @@ func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client
 		return err
 	}
 
-	//d := time.Millisecond
-	d := 1
+	d := 10 // seconds
 	err = docker.ContainerStop(context.Background(), resp.ID, container.StopOptions{Timeout: &d})
 	if err != nil {
 		return err

--- a/internal/bases/bases.go
+++ b/internal/bases/bases.go
@@ -20,11 +20,7 @@ import (
 
 var baseCreationMutex sync.Mutex
 
-type ClonePoolInterface interface {
-	TriggerGC()
-}
-
-func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client.Client, z *zfs.ZFS, clonepool ClonePoolInterface) error {
+func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client.Client, z *zfs.ZFS, snapCompletedCallback func()) error {
 	baseCreationMutex.Lock()
 	defer baseCreationMutex.Unlock()
 
@@ -128,8 +124,8 @@ func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client
 	if err != nil {
 		return err
 	}
-	if clonepool != nil {
-		clonepool.TriggerGC()
+	if snapCompletedCallback != nil {
+		snapCompletedCallback()
 	}
 	return err
 }

--- a/internal/bases/bases.go
+++ b/internal/bases/bases.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/modfin/zdap/internal"
-	"github.com/modfin/zdap/internal/clonepool"
 	"github.com/modfin/zdap/internal/zfs"
 	"os"
 	"os/exec"
@@ -21,7 +20,11 @@ import (
 
 var baseCreationMutex sync.Mutex
 
-func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client.Client, z *zfs.ZFS, clonepool *clonepool.ClonePool) error {
+type ClonePoolInterface interface {
+	TriggerGC()
+}
+
+func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client.Client, z *zfs.ZFS, clonepool ClonePoolInterface) error {
 	baseCreationMutex.Lock()
 	defer baseCreationMutex.Unlock()
 

--- a/internal/bases/bases.go
+++ b/internal/bases/bases.go
@@ -176,8 +176,7 @@ func DestroyClone(cloneName string, docker *client.Client, z *zfs.ZFS) error {
 			if strings.HasPrefix(name, "/"+cloneName) {
 				if c.State == "running" {
 					fmt.Println(" - Killing", name)
-					//d := time.Millisecond
-					d := 1
+					d := 0
 					err = docker.ContainerStop(context.Background(), c.ID, container.StopOptions{Timeout: &d})
 					if err != nil {
 						return err

--- a/internal/bases/bases.go
+++ b/internal/bases/bases.go
@@ -101,7 +101,7 @@ func CreateBaseAndSnap(resourcePath string, r *internal.Resource, docker *client
 		return err
 	}
 
-	d := 10 // seconds
+	d := 60 // seconds
 	err = docker.ContainerStop(context.Background(), resp.ID, container.StopOptions{Timeout: &d})
 	if err != nil {
 		return err

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -195,7 +195,6 @@ func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
 		timeout = maxTimeout
 	}
 	expires := time.Now().Add(timeout)
-	fmt.Println(claim.Dataset)
 	c.cloneContext.Z.WriteLock()
 	err = claim.Dataset.SetUserProperty(zfs.PropExpires, expires.Format(zfs.TimestampFormat))
 	c.cloneContext.Z.WriteUnlock()

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -165,6 +165,7 @@ func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
 	defer c.claimLock.Unlock()
 
 	dss, err := c.cloneContext.Z.Open()
+	defer dss.Close()
 	if err != nil {
 		return zdap.PublicClone{}, err
 	}
@@ -174,12 +175,13 @@ func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
 		dss.Close()
 
 		// reset dataset and query new clones
-		dss, err = c.cloneContext.Z.Open()
+		updatedDss, err := c.cloneContext.Z.Open()
+		defer updatedDss.Close()
 		if err != nil {
 			return zdap.PublicClone{}, err
 		}
 
-		claim, _ = c.getPooledClone(dss)
+		claim, _ = c.getPooledClone(updatedDss)
 	}
 
 	if claim == nil {

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -34,6 +34,9 @@ func (c *ClonePool) Start() {
 }
 
 func (c *ClonePool) action() {
+	c.expireLock.Lock()
+	defer c.expireLock.Unlock()
+
 	dss, err := c.cloneContext.Z.Open()
 	defer dss.Close()
 	if err != nil {
@@ -140,8 +143,8 @@ func (c *ClonePool) pruneExpired(dss *zfs.Dataset, clones []zdap.PublicClone) []
 }
 
 func (c *ClonePool) Expire(claimId string) error {
-	c.claimLock.Lock()
-	defer c.claimLock.Unlock()
+	c.expireLock.Lock()
+	defer c.expireLock.Unlock()
 	dss, err := c.cloneContext.Z.Open()
 	if err != nil {
 		return err

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -140,6 +140,7 @@ func (c *ClonePool) Expire(claimId string) error {
 	if err != nil {
 		return err
 	}
+	defer dss.Close()
 
 	pooled, err := c.readPooled(dss)
 	if err != nil {

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -29,6 +29,7 @@ func (c *ClonePool) Start() {
 			time.Sleep(time.Second)
 			dss, err := c.cloneContext.Z.Open()
 			if err != nil {
+				fmt.Printf("error trying to open z, error: %s\n", err.Error())
 				continue
 			}
 			//log.Info("Running clonepool for %s", c.resource.Name)

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+var GlobalExpireLock = sync.Mutex{}
+
 type ClonePool struct {
 	resource        internal.Resource
 	cloneContext    *cloning.CloneContext
@@ -35,8 +37,8 @@ func (c *ClonePool) Start() {
 }
 
 func (c *ClonePool) action() {
-	c.expireLock.Lock()
-	defer c.expireLock.Unlock()
+	GlobalExpireLock.Lock()
+	defer GlobalExpireLock.Unlock()
 
 	dss, err := c.cloneContext.Z.Open()
 	defer dss.Close()
@@ -139,8 +141,8 @@ func (c *ClonePool) pruneExpired(dss *zfs.Dataset, clones []zdap.PublicClone) []
 }
 
 func (c *ClonePool) Expire(claimId string) error {
-	c.expireLock.Lock()
-	defer c.expireLock.Unlock()
+	GlobalExpireLock.Lock()
+	defer GlobalExpireLock.Unlock()
 	dss, err := c.cloneContext.Z.Open()
 	if err != nil {
 		return err

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -135,6 +135,10 @@ func (c *ClonePool) pruneExpired(dss *zfs.Dataset, clones []zdap.PublicClone) []
 	})
 }
 
+func (c *ClonePool) Expire(claimId string) error {
+	return c.cloneContext.Z.Destroy(claimId)
+}
+
 func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
 	c.claimLock.Lock()
 	defer c.claimLock.Unlock()

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -182,10 +182,7 @@ func (c *ClonePool) Expire(claimId string) error {
 		return fmt.Errorf("found no matching clones")
 	}
 
-	c.cloneContext.Z.WriteLock()
-	err = match[0].Dataset.SetUserProperty(zfs.PropExpires, time.Now().Format(zfs.TimestampFormat))
-	c.cloneContext.Z.WriteUnlock()
-	return err
+	return c.cloneContext.Z.SetUserProperty(*match[0].Dataset, zfs.PropExpires, time.Now().Format(zfs.TimestampFormat))
 }
 
 func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
@@ -222,9 +219,7 @@ func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
 		timeout = maxTimeout
 	}
 	expires := time.Now().Add(timeout)
-	c.cloneContext.Z.WriteLock()
-	err = claim.Dataset.SetUserProperty(zfs.PropExpires, expires.Format(zfs.TimestampFormat))
-	c.cloneContext.Z.WriteUnlock()
+	err = c.cloneContext.Z.SetUserProperty(*claim.Dataset, zfs.PropExpires, expires.Format(zfs.TimestampFormat))
 	if err != nil {
 		return zdap.PublicClone{}, err
 	}

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -119,8 +119,8 @@ func (c *ClonePool) readPooled(dss *zfs.Dataset) ([]zdap.PublicClone, error) {
 }
 
 func (c *ClonePool) pruneExpired(dss *zfs.Dataset, clones []zdap.PublicClone) []zdap.PublicClone {
-	c.expireLock.Lock()
-	defer c.expireLock.Unlock()
+	c.claimLock.Lock()
+	defer c.claimLock.Unlock()
 
 	t := time.Now()
 	expired := slicez.Filter(clones, func(clone zdap.PublicClone) bool {
@@ -140,8 +140,8 @@ func (c *ClonePool) pruneExpired(dss *zfs.Dataset, clones []zdap.PublicClone) []
 }
 
 func (c *ClonePool) Expire(claimId string) error {
-	c.expireLock.Lock()
-	defer c.expireLock.Unlock()
+	c.claimLock.Lock()
+	defer c.claimLock.Unlock()
 	dss, err := c.cloneContext.Z.Open()
 	if err != nil {
 		return err

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -261,7 +261,6 @@ func (c *ClonePool) triggerGCAfterDelay(delay time.Duration) {
 	timer := time.NewTimer(delay)
 	go func() {
 		<-timer.C
-		fmt.Println("Triggering GC after delay") // debug log will remove
 		c.TriggerGC()
 	}()
 }

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -2,6 +2,7 @@ package clonepool
 
 import (
 	"fmt"
+	"github.com/labstack/gommon/log"
 	"github.com/modfin/henry/slicez"
 	"github.com/modfin/zdap"
 	"github.com/modfin/zdap/internal"
@@ -43,7 +44,6 @@ func (c *ClonePool) action() {
 		fmt.Printf("error trying to open z, error: %s\n", err.Error())
 		return
 	}
-	//log.Info("Running clonepool for %s", c.resource.Name)
 
 	allClones, err := c.readPooled(dss)
 	if err != nil {
@@ -64,10 +64,7 @@ func (c *ClonePool) action() {
 	if nbrClones+clonesToAdd > c.resource.ClonePool.MaxClones {
 		clonesToAdd = c.resource.ClonePool.MaxClones - nbrClones
 	}
-	//log.Infof("min: %d", c.resource.ClonePool.MinClones)
-	//log.Infof("max: %d", c.resource.ClonePool.MaxClones)
-	//log.Infof("nbr: %d", nbrClones)
-	//log.Infof("adding: %d", clonesToAdd)
+
 	for i := 0; i < clonesToAdd; i++ {
 		_, err := c.addCloneToPool(dss)
 		if err != nil {
@@ -80,7 +77,6 @@ func (c *ClonePool) action() {
 		c.claimLock.Unlock()
 	}
 
-	//log.Info("Finished running clone pool")
 }
 
 func (c *ClonePool) getAvailableClones(dss *zfs.Dataset) ([]zdap.PublicClone, error) {
@@ -107,7 +103,7 @@ func (c *ClonePool) addCloneToPool(dss *zfs.Dataset) (*zdap.PublicClone, error) 
 	})
 	latestDate := snaps[0].CreatedAt
 
-	//log.Infof("Adding clone to %s pool", c.resource.Name)
+	log.Infof("Adding clone to %s pool", c.resource.Name)
 	return c.cloneContext.CloneResourcePooled(dss, "zdapd", c.resource.Name, latestDate)
 }
 

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -47,9 +47,11 @@ func (c *ClonePool) action() {
 		return
 	}
 
-	err = c.expireClonesFromOldSnaps(dss)
-	if err != nil {
-		fmt.Printf("could not expire old clones, error %s", err)
+	if c.resource.ClonePool.ResetOnNewSnap {
+		err = c.expireClonesFromOldSnaps(dss)
+		if err != nil {
+			fmt.Printf("could not expire old clones, error %s", err)
+		}
 	}
 
 	nonExpiredClones := c.pruneExpired(dss, allClones)

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -185,7 +185,7 @@ func (c *ClonePool) expire(dss *zfs.Dataset, claimId string) error {
 	return c.cloneContext.Z.SetUserProperty(*match[0].Dataset, zfs.PropExpires, time.Now().Format(zfs.TimestampFormat))
 }
 
-func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
+func (c *ClonePool) Claim(timeout time.Duration, owner string) (zdap.PublicClone, error) {
 	c.claimLock.Lock()
 	defer c.claimLock.Unlock()
 
@@ -229,6 +229,10 @@ func (c *ClonePool) Claim(timeout time.Duration) (zdap.PublicClone, error) {
 		return zdap.PublicClone{}, err
 	}
 	c.ClonesAvailable--
+	err = c.cloneContext.Z.SetUserProperty(*claim.Dataset, zfs.PropOwner, owner)
+	if err != nil {
+		return zdap.PublicClone{}, err
+	}
 
 	claim.APIPort = c.cloneContext.ApiPort
 	claim.Server = c.cloneContext.NetworkAddress

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -142,8 +142,8 @@ func (c *ClonePool) readPooled(dss *zfs.Dataset) ([]zdap.PublicClone, error) {
 }
 
 func (c *ClonePool) pruneExpired(dss *zfs.Dataset, clones []zdap.PublicClone) []zdap.PublicClone {
-	c.claimLock.Lock()
-	defer c.claimLock.Unlock()
+	//c.claimLock.Lock()
+	//defer c.claimLock.Unlock()
 
 	t := time.Now()
 	expired := slicez.Filter(clones, func(clone zdap.PublicClone) bool {

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -258,9 +258,8 @@ func (c *ClonePool) Claim(timeout time.Duration, owner string) (zdap.PublicClone
 }
 
 func (c *ClonePool) triggerGCAfterDelay(delay time.Duration) {
-	timer := time.NewTimer(delay)
 	go func() {
-		<-timer.C
+		time.Sleep(delay)
 		c.TriggerGC()
 	}()
 }

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -142,9 +142,6 @@ func (c *ClonePool) readPooled(dss *zfs.Dataset) ([]zdap.PublicClone, error) {
 }
 
 func (c *ClonePool) pruneExpired(dss *zfs.Dataset, clones []zdap.PublicClone) []zdap.PublicClone {
-	//c.claimLock.Lock()
-	//defer c.claimLock.Unlock()
-
 	t := time.Now()
 	expired := slicez.Filter(clones, func(clone zdap.PublicClone) bool {
 		return clone.ExpiresAt != nil && clone.ExpiresAt.Before(t)

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -85,7 +85,7 @@ func (c *CloneContext) GetLatestResourceSnap(dss *zfs.Dataset, resourceName stri
 	}
 
 	sort.Slice(snaps, func(i, j int) bool {
-		return snaps[i].CreatedAt.Before(snaps[j].CreatedAt)
+		return snaps[j].CreatedAt.Before(snaps[i].CreatedAt)
 	})
 
 	if len(snaps) == 0 {

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -130,13 +130,13 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		ExposedPorts: nat.PortSet{
 			nat.Port(fmt.Sprintf("%d/tcp", r.Docker.Port)): struct{}{},
 		},
-		//Healthcheck: &container.HealthConfig{
-		//	Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
-		//	Interval:    1 * time.Second,
-		//	Timeout:     1 * time.Second,
-		//	StartPeriod: 1 * time.Second,
-		//	Retries:     1,
-		//},
+		Healthcheck: &container.HealthConfig{
+			Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
+			Interval:    1 * time.Second,
+			Timeout:     10 * time.Second,
+			StartPeriod: 1 * time.Second,
+			Retries:     1,
+		},
 	}, &container.HostConfig{
 		RestartPolicy: container.RestartPolicy{
 			Name:              "unless-stopped",

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -130,13 +130,13 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		ExposedPorts: nat.PortSet{
 			nat.Port(fmt.Sprintf("%d/tcp", r.Docker.Port)): struct{}{},
 		},
-		Healthcheck: &container.HealthConfig{
-			Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
-			Interval:    1 * time.Second,
-			Timeout:     10 * time.Second,
-			StartPeriod: 1 * time.Second,
-			Retries:     1,
-		},
+		//Healthcheck: &container.HealthConfig{
+		//	Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
+		//	Interval:    1 * time.Second,
+		//	Timeout:     10 * time.Second,
+		//	StartPeriod: 1 * time.Second,
+		//	Retries:     1,
+		//},
 	}, &container.HostConfig{
 		RestartPolicy: container.RestartPolicy{
 			Name:              "unless-stopped",

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -205,12 +205,10 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		},
 	}, networkConfig, nil, fmt.Sprintf("%s-proxy", cloneName))
 	if err != nil {
-		fmt.Printf("Error when creating 2nd container")
 		return nil, err
 	}
 	err = docker.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{})
 	if err != nil {
-		fmt.Printf("Error when starting 2nd container")
 		return nil, err
 	}
 	fmt.Println(" - db proxy name", fmt.Sprintf("tcp://%s-proxy:%d", cloneName, port))

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -18,7 +18,6 @@ import (
 	"github.com/modfin/zdap/internal/zfs"
 	"regexp"
 	"sort"
-	"sync"
 	"time"
 )
 
@@ -95,12 +94,7 @@ func (c *CloneContext) GetLatestResourceSnap(dss *zfs.Dataset, resourceName stri
 	return snaps[0], nil
 }
 
-var cloneCreationMutex = sync.Mutex{}
-
 func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resource, docker *client.Client, z *zfs.ZFS, clonePooled bool) (*zdap.PublicClone, error) {
-	cloneCreationMutex.Lock()
-	defer cloneCreationMutex.Unlock()
-
 	net, err := bases.EnsureNetwork(docker)
 	if err != nil {
 		return nil, err

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -225,7 +225,9 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 	if matchingClones != nil && len(matchingClones) > 0 {
 		fmt.Printf("Setting healthy for %s\n", cloneName)
 		m := matchingClones[0]
+		z.WriteLock()
 		m.Dataset.SetUserProperty(zfs.PropHealthy, "true")
+		z.WriteUnlock()
 		defer m.Dataset.Close()
 	}
 

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -151,12 +151,10 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		},
 	}, networkConfig, nil, cloneName)
 	if err != nil {
-		fmt.Printf("Error when creating 1st container")
 		return nil, err
 	}
 	err = docker.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{})
 	if err != nil {
-		fmt.Printf("Error when starting 1st container")
 		return nil, err
 	}
 
@@ -223,9 +221,7 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		return nil, err
 	}
 
-	fmt.Printf("Trying to find clone matching %s", cloneName)
 	matchingClones := slicez.Filter(clones, func(c zdap.PublicClone) bool {
-		fmt.Printf(c.Name)
 		return c.Name == cloneName
 	})
 	if matchingClones != nil && len(matchingClones) > 0 {
@@ -233,10 +229,11 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		m := matchingClones[0]
 		z.WriteLock()
 		err := m.Dataset.SetUserProperty(zfs.PropHealthy, "true")
-		if err != nil {
-			fmt.Printf("Error %s", err)
-		}
 		z.WriteUnlock()
+		if err != nil {
+			fmt.Printf("Error when setting healthy prop %s", err)
+			return nil, err
+		}
 		defer m.Dataset.Close()
 	}
 

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -232,7 +232,10 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		fmt.Printf("Setting healthy for %s\n", cloneName)
 		m := matchingClones[0]
 		z.WriteLock()
-		m.Dataset.SetUserProperty(zfs.PropHealthy, "true")
+		err := m.Dataset.SetUserProperty(zfs.PropHealthy, "true")
+		if err != nil {
+			fmt.Printf("Error %s", err)
+		}
 		z.WriteUnlock()
 		defer m.Dataset.Close()
 	}

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -151,10 +151,12 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		},
 	}, networkConfig, nil, cloneName)
 	if err != nil {
+		fmt.Printf("Error when creating 1st container")
 		return nil, err
 	}
 	err = docker.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{})
 	if err != nil {
+		fmt.Printf("Error when starting 1st container")
 		return nil, err
 	}
 
@@ -187,10 +189,12 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		},
 	}, networkConfig, nil, fmt.Sprintf("%s-proxy", cloneName))
 	if err != nil {
+		fmt.Printf("Error when creating 2nd container")
 		return nil, err
 	}
 	err = docker.ContainerStart(context.Background(), resp.ID, types.ContainerStartOptions{})
 	if err != nil {
+		fmt.Printf("Error when starting 2nd container")
 		return nil, err
 	}
 	fmt.Println(" - db proxy name", fmt.Sprintf("tcp://%s-proxy:%d", cloneName, port))

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -219,7 +219,9 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		return nil, err
 	}
 
+	fmt.Printf("Trying to find clone matching %s", cloneName)
 	matchingClones := slicez.Filter(clones, func(c zdap.PublicClone) bool {
+		fmt.Printf(c.Name)
 		return c.Name == cloneName
 	})
 	if matchingClones != nil && len(matchingClones) > 0 {

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -130,13 +130,13 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		ExposedPorts: nat.PortSet{
 			nat.Port(fmt.Sprintf("%d/tcp", r.Docker.Port)): struct{}{},
 		},
-		//Healthcheck: &container.HealthConfig{
-		//	Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
-		//	Interval:    1 * time.Second,
-		//	Timeout:     10 * time.Second,
-		//	StartPeriod: 1 * time.Second,
-		//	Retries:     1,
-		//},
+		Healthcheck: &container.HealthConfig{
+			Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
+			Interval:    1 * time.Second,
+			Timeout:     1 * time.Second,
+			StartPeriod: 1 * time.Second,
+			Retries:     5,
+		},
 	}, &container.HostConfig{
 		RestartPolicy: container.RestartPolicy{
 			Name:              "unless-stopped",

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -108,7 +108,7 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 
 	networkConfig := &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{
-			net.Name: &network.EndpointSettings{},
+			net.Name: {},
 		},
 	}
 
@@ -245,9 +245,7 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 	if matchingClones != nil && len(matchingClones) > 0 {
 		fmt.Printf("Setting healthy for %s\n", cloneName)
 		m := matchingClones[0]
-		z.WriteLock()
-		err := m.Dataset.SetUserProperty(zfs.PropHealthy, "true")
-		z.WriteUnlock()
+		err := z.SetUserProperty(*m.Dataset, zfs.PropHealthy, "true")
 		if err != nil {
 			fmt.Printf("Error when setting healthy prop %s", err)
 			return nil, err

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -130,13 +130,13 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 		ExposedPorts: nat.PortSet{
 			nat.Port(fmt.Sprintf("%d/tcp", r.Docker.Port)): struct{}{},
 		},
-		Healthcheck: &container.HealthConfig{
-			Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
-			Interval:    1 * time.Second,
-			Timeout:     1 * time.Second,
-			StartPeriod: 1 * time.Second,
-			Retries:     1,
-		},
+		//Healthcheck: &container.HealthConfig{
+		//	Test:        []string{"CMD-SHELL", r.Docker.Healthcheck},
+		//	Interval:    1 * time.Second,
+		//	Timeout:     1 * time.Second,
+		//	StartPeriod: 1 * time.Second,
+		//	Retries:     1,
+		//},
 	}, &container.HostConfig{
 		RestartPolicy: container.RestartPolicy{
 			Name:              "unless-stopped",

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -65,17 +65,18 @@ func (c *Core) Start() error {
 	for _, r := range c.resources {
 		r := r
 
-		id, err := c.cron.AddFunc(r.Cron, func() {
-			fmt.Println("[CRON] Starting cron job to create", r.Name, "base resource")
-			err := bases.CreateBaseAndSnap(c.configDir, &r, c.docker, c.z)
+		if r.Cron != "" {
+			id, err := c.cron.AddFunc(r.Cron, func() {
+				fmt.Println("[CRON] Starting cron job to create", r.Name, "base resource")
+				err := bases.CreateBaseAndSnap(c.configDir, &r, c.docker, c.z)
+				if err != nil {
+					fmt.Println("[CRON] Error: could not run cronjob to create base,", err)
+				}
+			})
 			if err != nil {
-				fmt.Println("[CRON] Error: could not run cronjob to create base,", err)
+				return fmt.Errorf("could not create cron for '%s', %w", r.Cron, err)
 			}
-		})
-		ids = append(ids, id)
-
-		if err != nil {
-			return fmt.Errorf("could not create cron for '%s', %w", r.Cron, err)
+			ids = append(ids, id)
 		}
 
 		cloneContext := cloning.CloneContext{

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -79,17 +79,17 @@ func (c *Core) Start() error {
 			ids = append(ids, id)
 		}
 
-		//cloneContext := cloning.CloneContext{
-		//	Resource:       &r,
-		//	Docker:         c.docker,
-		//	Z:              c.z,
-		//	ConfigDir:      c.configDir,
-		//	NetworkAddress: c.networkAddress,
-		//	ApiPort:        c.apiPort,
-		//}
-		//clonePool := clonepool.NewClonePool(r, &cloneContext)
-		//clonePool.Start()
-		//c.clonePools[r.Name] = &clonePool
+		cloneContext := cloning.CloneContext{
+			Resource:       &r,
+			Docker:         c.docker,
+			Z:              c.z,
+			ConfigDir:      c.configDir,
+			NetworkAddress: c.networkAddress,
+			ApiPort:        c.apiPort,
+		}
+		clonePool := clonepool.NewClonePool(r, &cloneContext)
+		clonePool.Start()
+		c.clonePools[r.Name] = &clonePool
 	}
 	c.cron.Start()
 	for i, r := range c.resources {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -542,3 +542,10 @@ func (c *Core) ClaimPooledClone(resource string, timeout time.Duration) (zdap.Pu
 	}
 	return zdap.PublicClone{}, fmt.Errorf("no clone pool exists for resource '%s'", resource)
 }
+
+func (c *Core) ExpirePooledClone(resource string, claimId string) error {
+	if pool, exists := c.clonePools[resource]; exists {
+		return pool.Expire(claimId)
+	}
+	return nil
+}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -71,6 +71,7 @@ func (c *Core) Start() error {
 			}
 			clonePool = clonepool.NewClonePool(r, &cloneContext)
 			clonePool.Start()
+			clonePool.TriggerGC() // initial trigger needed to collect up-to-date stats
 			c.clonePools[r.Name] = clonePool
 		}
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -402,9 +402,9 @@ func (c *Core) ServerStatus(dss *zfs.Dataset) (zdap.ServerStatus, error) {
 	return s, nil
 }
 
-func (c *Core) ClaimPooledClone(resource string, timeout time.Duration) (zdap.PublicClone, error) {
+func (c *Core) ClaimPooledClone(resource string, timeout time.Duration, owner string) (zdap.PublicClone, error) {
 	if pool, exists := c.clonePools[resource]; exists {
-		return pool.Claim(timeout)
+		return pool.Claim(timeout, owner)
 	}
 	return zdap.PublicClone{}, fmt.Errorf("no clone pool exists for resource '%s'", resource)
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -79,17 +79,17 @@ func (c *Core) Start() error {
 			ids = append(ids, id)
 		}
 
-		cloneContext := cloning.CloneContext{
-			Resource:       &r,
-			Docker:         c.docker,
-			Z:              c.z,
-			ConfigDir:      c.configDir,
-			NetworkAddress: c.networkAddress,
-			ApiPort:        c.apiPort,
-		}
-		clonePool := clonepool.NewClonePool(r, &cloneContext)
-		clonePool.Start()
-		c.clonePools[r.Name] = &clonePool
+		//cloneContext := cloning.CloneContext{
+		//	Resource:       &r,
+		//	Docker:         c.docker,
+		//	Z:              c.z,
+		//	ConfigDir:      c.configDir,
+		//	NetworkAddress: c.networkAddress,
+		//	ApiPort:        c.apiPort,
+		//}
+		//clonePool := clonepool.NewClonePool(r, &cloneContext)
+		//clonePool.Start()
+		//c.clonePools[r.Name] = &clonePool
 	}
 	c.cron.Start()
 	for i, r := range c.resources {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -79,17 +79,19 @@ func (c *Core) Start() error {
 			ids = append(ids, id)
 		}
 
-		cloneContext := cloning.CloneContext{
-			Resource:       &r,
-			Docker:         c.docker,
-			Z:              c.z,
-			ConfigDir:      c.configDir,
-			NetworkAddress: c.networkAddress,
-			ApiPort:        c.apiPort,
+		if r.ClonePool.MinClones != 0 {
+			cloneContext := cloning.CloneContext{
+				Resource:       &r,
+				Docker:         c.docker,
+				Z:              c.z,
+				ConfigDir:      c.configDir,
+				NetworkAddress: c.networkAddress,
+				ApiPort:        c.apiPort,
+			}
+			clonePool := clonepool.NewClonePool(r, &cloneContext)
+			clonePool.Start()
+			c.clonePools[r.Name] = &clonePool
 		}
-		clonePool := clonepool.NewClonePool(r, &cloneContext)
-		clonePool.Start()
-		c.clonePools[r.Name] = &clonePool
 	}
 	c.cron.Start()
 	for i, r := range c.resources {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -471,6 +471,7 @@ func (c *Core) DestroyClone(dss *zfs.Dataset, cloneName string) error {
 		}
 	}
 	if !contain {
+		fmt.Println("not contain")
 		return fmt.Errorf("clone, %s, does not exist", cloneName)
 	}
 

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -9,7 +9,7 @@ func Test_loadResources(t *testing.T) {
 	rs, err := loadResources("./testdata/resources")
 	assert.NoError(t, err)
 	assert.Len(t, rs, 1)
-	assert.Equal(t, "postgres-trade", rs[0].Name)
+	assert.Equal(t, "postgres-dbname", rs[0].Name)
 	assert.Equal(t, 8, rs[0].ClonePool.MinClones)
 	assert.Equal(t, 16, rs[0].ClonePool.MaxClones)
 }

--- a/internal/core/testdata/resources/test.resource.yml
+++ b/internal/core/testdata/resources/test.resource.yml
@@ -16,4 +16,3 @@ clone_pool:
   min_clones: 8
   max_clones: 16
   claim_max_timeout_seconds: 300
-  claim_taints_clone: true

--- a/internal/core/testdata/resources/test.resource.yml
+++ b/internal/core/testdata/resources/test.resource.yml
@@ -1,6 +1,6 @@
-name: postgres-trade
+name: postgres-dbname
 docker:
-  image: eu.gcr.io/spidercave/lib/postgres:15.3
+  image: postgres:15.3-bullseye
   port: 5432
   volume: /var/lib/postgresql/data
   env:
@@ -9,8 +9,8 @@ docker:
   ## Health Check must exist in order to know when the container is really started
   healthcheck: echo SELECT 1 | psql -U postgres
 cron: 45 4 * * *
-retrieval: ./postgres-trade.retrieval.sh
-creation: ./postgres-trade.creation.sh
+retrieval: ./postgres-dbname.retrieval.sh
+creation: ./postgres-dbname.creation.sh
 clone_pool:
   reset_on_new_snap: true
   min_clones: 8

--- a/internal/resource.go
+++ b/internal/resource.go
@@ -18,11 +18,13 @@ type Docker struct {
 	Healthcheck string
 }
 
-const DefaultClaimMaxTimeoutSeconds = 300
+const DefaultClaimTimeoutSeconds = 300
+const DefaultClaimMaxTimeoutSeconds = 90000
 
 type ClonePoolConfig struct {
 	ResetOnNewSnap         bool `yaml:"reset_on_new_snap" json:"reset_on_new_snap"`
 	MinClones              int  `yaml:"min_clones" json:"min_clones"`
 	MaxClones              int  `yaml:"max_clones" json:"max_clones"`
 	ClaimMaxTimeoutSeconds int  `yaml:"claim_max_timeout_seconds" json:"claim_max_timeout_seconds"`
+	DefaultTimeoutSeconds  int  `yaml:"claim_default_timeout_seconds" json:"claim_default_timeout_seconds"`
 }

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -96,6 +96,7 @@ func (z *ZFS) destroyDatasetRec(path string) error {
 		return err
 		//return fmt.Errorf("could not open ds: %w", err)
 	}
+	defer dataset.Close()
 	z.writeLock()
 	err = dataset.UnmountAll(0)
 	z.writeUnlock()

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -379,7 +379,7 @@ func (z *ZFS) listReg(dss *Dataset, reg *regexp.Regexp) ([]string, error) {
 }
 
 func (z *ZFS) SnapDataset(name string, resource string, created time.Time) error {
-	ds, err := zfs.DatasetSnapshot(fmt.Sprintf("%s/%s@snap", z.pool, name), false, nil, nil)
+	ds, err := zfs.DatasetSnapshot(fmt.Sprintf("%s/%s@snap", z.pool, name), false, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -91,7 +91,7 @@ func (z *ZFS) CreateDataset(name string, resource string, creation time.Time) (s
 func (z *ZFS) destroyDatasetRec(path string) error {
 	dataset, err := zfs.DatasetOpen(path)
 	if err != nil {
-		return nil
+		return err
 		//return fmt.Errorf("could not open ds: %w", err)
 	}
 	err = dataset.UnmountAll(0)
@@ -153,8 +153,8 @@ func (z *ZFS) destroyDatasetRec(path string) error {
 }
 
 func (z *ZFS) Destroy(name string) error {
-	z.writeLock()
-	defer z.writeUnlock()
+	//z.writeLock()
+	//defer z.writeUnlock()
 	return z.destroyDatasetRec(fmt.Sprintf("%s/%s", z.pool, name))
 }
 

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -89,12 +89,16 @@ func (z *ZFS) CreateDataset(name string, resource string, creation time.Time) (s
 }
 
 func (z *ZFS) destroyDatasetRec(path string) error {
+	z.readLock()
 	dataset, err := zfs.DatasetOpen(path)
+	z.readUnlock()
 	if err != nil {
 		return err
 		//return fmt.Errorf("could not open ds: %w", err)
 	}
+	z.writeLock()
 	err = dataset.UnmountAll(0)
+	z.writeUnlock()
 
 	if err != nil {
 		return fmt.Errorf("could not unmout all: %w", err)

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -383,6 +383,9 @@ func (z *ZFS) listReg(dss *Dataset, reg *regexp.Regexp) ([]string, error) {
 }
 
 func (z *ZFS) SnapDataset(name string, resource string, created time.Time) error {
+	z.WriteLock()
+	defer z.WriteUnlock()
+
 	ds, err := zfs.DatasetSnapshot(fmt.Sprintf("%s/%s@snap", z.pool, name), false, nil)
 	if err != nil {
 		return err
@@ -401,6 +404,8 @@ func (z *ZFS) SnapDataset(name string, resource string, created time.Time) error
 }
 
 func (z *ZFS) CloneDataset(owner, snapName string, port int, clonePooled bool) (string, string, error) {
+	z.WriteLock()
+	defer z.WriteUnlock()
 
 	parts := strings.Split(snapName, "@")
 	if len(parts) != 2 {

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -163,15 +163,10 @@ func (z *ZFS) destroyDatasetRec(path string) error {
 }
 
 func (z *ZFS) Destroy(name string) error {
-	//z.writeLock()
-	//defer z.writeUnlock()
 	return z.destroyDatasetRec(fmt.Sprintf("%s/%s", z.pool, name))
 }
 
 func (z *ZFS) DestroyAll() error {
-	//z.writeLock()
-	//defer z.writeUnlock()
-
 	z.readLock()
 	ds, err := zfs.DatasetOpen(z.pool)
 	z.readUnlock()

--- a/internal/zfs/zfs.go
+++ b/internal/zfs/zfs.go
@@ -59,6 +59,9 @@ func (z *ZFS) GetDatasetSnapNameAt(name string, at time.Time) string {
 }
 
 func (z *ZFS) CreateDataset(name string, resource string, creation time.Time) (string, error) {
+	z.WriteLock()
+	defer z.WriteUnlock()
+
 	ds, err := zfs.DatasetCreate(fmt.Sprintf("%s/%s", z.pool, name), zfs.DatasetTypeFilesystem, nil)
 	if err != nil {
 		return "", err
@@ -156,6 +159,9 @@ func (z *ZFS) Destroy(name string) error {
 }
 
 func (z *ZFS) DestroyAll() error {
+	z.WriteLock()
+	defer z.WriteUnlock()
+
 	ds, err := zfs.DatasetOpen(z.pool)
 
 	if err != nil {

--- a/run-zpeedapd.sh
+++ b/run-zpeedapd.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-export NETWORK_ADDRESS=10.200.1.212
-export ZPOOL=zdap-pool/databases
-export API_PORT=43210
-export CONFIG_DIR=/zdap/config
-
-go run cmd/zdapd/zdapd.go $@


### PR DESCRIPTION
Extend zdap with a dynamic clone pool per resource, that can be claimed for testing and then automatically discarded. Each pooled clone sets an expiration date as a zfs property.

Each resource that is configured to use a clone pool has a clone pool worker that runs every hour, or when something is added to its buffered (1) channel. The action will:
1. Expire all clones that are based on a snap older than the latest snap.
2. Remove expired clones.
3. Add clones to the pool to reach the configured minimum value of available clones.

Each claim and new snap immediately adds to the clone pool workers queue, and each claim also starts a goroutine that sleeps until its expiration and then adds itself to the queue. This ensures that it runs every time we know some action is needed, but doesn't run all the time and hogs resources/locks. The reason behind the 1 buffer space in the channel is to ensure that any time anyone adds to the queue, a complete action run is guaranteed to happen either immediately or as soon as the current action finishes. 

I also removed our replace directive for lib-zfs and upgraded the version to the latest one. This seems to have solved the segfaults we were getting before, when claiming and destroying lots of claims. 

It seems that modifying any dataset and opening the entire pool concurrently causes segfaults with both the old and the new lib. (reproduced on current "live" servers by concurrently running two loops attaching/detaching) I've tried solving this by adding a RW lock, where Open() is wrapped with claiming the read lock and all mutations are wrapped in a write lock. All mutations then need to go through zfs.go.

This should probably be extended with better interfaces that wrap the internal zfs stuff, so you really cannot mutate anything from outside zfs.go. Another likely useful extension is to keep a copy of all local zfs state in memory, so we don't need to traverse the datasets unnecessarily. Then once you've found what you're looking for, e.g. a clone, you can open only that dataset and hopefully you then won't need to lock everything. 