### PR TITLE
Pull zdap-proxy image when attaching a new clone

### DIFF
--- a/cmd/zdap/commands/clone.go
+++ b/cmd/zdap/commands/clone.go
@@ -439,7 +439,7 @@ func AttachClone(c *cli.Context) error {
 	}
 
 	container := compose.Container{}
-	container.Image = "crholm/zdap-proxy:latest"
+	container.Image = "modfin/zdap-proxy:latest"
 	container.Ports = ports
 	container.Environment = []string{
 		fmt.Sprintf("LISTEN_PORT=%d", port),

--- a/internal/cloning/cloning.go
+++ b/internal/cloning/cloning.go
@@ -16,6 +16,8 @@ import (
 	"github.com/modfin/zdap/internal/bases"
 	"github.com/modfin/zdap/internal/utils"
 	"github.com/modfin/zdap/internal/zfs"
+	"io"
+	"os"
 	"regexp"
 	"sort"
 	"time"
@@ -133,6 +135,17 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 	}
 	fmt.Println(" - clone name", cloneName)
 
+	// Pull zdap-proxy image
+	proxyImageName := "modfin/zdap-proxy:latest"
+	reader, err := docker.ImagePull(context.Background(), proxyImageName, types.ImagePullOptions{})
+	if err != nil {
+		return nil, err
+	}
+	_, err = io.Copy(os.Stdout, reader)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := docker.ContainerCreate(context.Background(), &container.Config{
 		Image:      r.Docker.Image,
 		Env:        r.Docker.Env,
@@ -173,12 +186,8 @@ func createClone(dss *zfs.Dataset, owner string, snap string, r *internal.Resour
 
 	fmt.Println(" - db container name", cloneName)
 
-	if err != nil {
-		return nil, err
-	}
-
 	resp, err = docker.ContainerCreate(context.Background(), &container.Config{
-		Image: "crholm/zdap-proxy:latest",
+		Image: proxyImageName,
 		Env: []string{
 			fmt.Sprintf("LISTEN_PORT=%d", port),
 			fmt.Sprintf("TARGET_ADDRESS=%s:%d", cloneName, r.Docker.Port),

--- a/models.go
+++ b/models.go
@@ -37,7 +37,7 @@ type PublicClone struct {
 func (c *PublicClone) YAML(listenPort int) string {
 	return fmt.Sprintf(`
   %s:
-    image: crholm/zdap-proxy:latest
+    image: modfin/zdap-proxy:latest
     environment:
       - LISTEN_PORT=%d
       - TARGET_ADDRESS=%s:%d


### PR DESCRIPTION
There are instances where the zdap-proxy image is overwritten when building an overridden Dockerfile, causing zdap to be disabled. So when we are about to attach a new clone, do a pull to make sure that we are using the correct zdap-proxy image.