### PR TITLE
Add support to set ZFS properties and container params

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -2,14 +2,15 @@ package api
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/modfin/zdap"
 	"github.com/modfin/zdap/internal/core"
 	"github.com/modfin/zdap/internal/servermodel"
 	"github.com/modfin/zdap/internal/utils"
 	"github.com/modfin/zdap/internal/zfs"
-	"sort"
-	"strings"
-	"time"
 )
 
 func getStatus(dss *zfs.Dataset, app *core.Core) (zdap.ServerStatus, error) {
@@ -68,7 +69,7 @@ func getSnap(dss *zfs.Dataset, owner string, createdAt time.Time, resource strin
 			continue
 		}
 		t.Clones, err = getClones(dss, owner, t.CreatedAt, resource, app)
-		return &t, nil
+		return &t, err
 	}
 	return nil, fmt.Errorf("could not find snap %s@%s", resource, createdAt.Format(utils.TimestampFormat))
 }
@@ -115,7 +116,7 @@ func getClones(dss *zfs.Dataset, owner string, snap time.Time, resource string, 
 		return nil, err
 	}
 	for _, c := range cc[snap] {
-		if strings.ToLower(c.Owner) == strings.ToLower(owner) {
+		if strings.EqualFold(c.Owner, owner) {
 			clones = append(clones, c)
 		}
 	}

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -3,6 +3,11 @@ package api
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/modfin/zdap/internal"
 	"github.com/modfin/zdap/internal/config"
@@ -10,11 +15,7 @@ import (
 	"github.com/modfin/zdap/internal/servermodel"
 	"github.com/modfin/zdap/internal/utils"
 	"github.com/modfin/zdap/internal/zfs"
-	"net/http"
-	"strconv"
-	"time"
 )
-import "github.com/labstack/echo/v4"
 
 func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 	e := echo.New()
@@ -139,6 +140,9 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 			for _, clone := range snap.Clones {
 				if clone.CreatedAt.Equal(at) {
 					err = app.DestroyClone(dss, clone.Name)
+					if err != nil {
+						return err
+					}
 					return c.NoContent(http.StatusOK)
 				}
 			}
@@ -189,6 +193,9 @@ func Start(cfg *config.Config, app *core.Core, z *zfs.ZFS) error {
 	e.POST("/resources/:resource/snaps/:createdAt", func(c echo.Context) error {
 		resource := c.Param("resource")
 		at, err := time.Parse(utils.TimestampFormat, c.Param("createdAt"))
+		if err != nil {
+			return err
+		}
 
 		dss, err := z.Open()
 		if err != nil {

--- a/internal/clonepool/clonepool.go
+++ b/internal/clonepool/clonepool.go
@@ -47,11 +47,11 @@ func (c *ClonePool) TriggerGC() {
 func (c *ClonePool) action() {
 
 	dss, err := c.cloneContext.Z.Open()
-	defer dss.Close()
 	if err != nil {
 		fmt.Printf("error trying to open z, error: %s\n", err.Error())
 		return
 	}
+	defer dss.Close()
 
 	allClones, err := c.readPooled(dss)
 	if err != nil {
@@ -207,10 +207,10 @@ func (c *ClonePool) Claim(timeout time.Duration, owner string) (servermodel.Serv
 	defer c.claimLock.Unlock()
 
 	dss, err := c.cloneContext.Z.Open()
-	defer dss.Close()
 	if err != nil {
 		return servermodel.ServerInternalClone{}, err
 	}
+	defer dss.Close()
 	claim, err := c.getPooledClone(dss)
 	if err != nil {
 		fmt.Printf("Failed to get pooled clone, will attempt to add one: %s\n", err.Error())
@@ -224,10 +224,10 @@ func (c *ClonePool) Claim(timeout time.Duration, owner string) (servermodel.Serv
 
 		// reset dataset and query new clones
 		updatedDss, err := c.cloneContext.Z.Open()
-		defer updatedDss.Close()
 		if err != nil {
 			return servermodel.ServerInternalClone{}, err
 		}
+		defer updatedDss.Close()
 
 		claim, _ = c.getPooledClone(updatedDss)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/caarlos0/env"
-	"github.com/urfave/cli/v2"
 	"log"
 	"sync"
+
+	"github.com/caarlos0/env"
+	"github.com/urfave/cli/v2"
 )
 
 type Config struct {
@@ -40,7 +41,7 @@ func FromCli(c *cli.Context) *Config {
 			cfg.ConfigDir = c.String("config-dir")
 		}
 		if c.IsSet("network-address") {
-			cfg.ConfigDir = c.String("network-address")
+			cfg.NetworkAddress = c.String("network-address")
 		}
 		if c.IsSet("api-port") {
 			cfg.APIPort = c.Int("api-port")

--- a/internal/resource.go
+++ b/internal/resource.go
@@ -1,19 +1,31 @@
 package internal
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types/strslice"
+	"github.com/modfin/henry/slicez"
+)
+
 type Resource struct {
-	Name      string
-	Alias     string
-	Retrieval string
-	Creation  string
-	Cron      string
-	Docker    Docker
-	ClonePool ClonePoolConfig `yaml:"clone_pool"`
+	Name          string
+	Alias         string
+	Retrieval     string
+	Creation      string
+	Cron          string
+	Docker        Docker
+	ClonePool     ClonePoolConfig `yaml:"clone_pool"`
+	RestoreParams ContainerParams `yaml:"restore_params"`
+	CloneParams   ContainerParams `yaml:"clone_params"`
 }
 
 type Docker struct {
 	Image       string
 	Port        int
 	Env         []string
+	Entrypoint  []string
+	Cmd         []string
 	Volume      string
 	Healthcheck string
 	Shm         int64
@@ -28,4 +40,80 @@ type ClonePoolConfig struct {
 	MaxClones              int  `yaml:"max_clones" json:"max_clones"`
 	ClaimMaxTimeoutSeconds int  `yaml:"claim_max_timeout_seconds" json:"claim_max_timeout_seconds"`
 	DefaultTimeoutSeconds  int  `yaml:"claim_default_timeout_seconds" json:"claim_default_timeout_seconds"`
+}
+
+type ContainerParams struct {
+	Env           []string
+	Entrypoint    []string
+	Cmd           []string
+	ZfsProperties []string `yaml:"zfs"`
+}
+
+func (r Resource) BaseCmd() strslice.StrSlice {
+	if len(r.Docker.Cmd) == 0 && len(r.RestoreParams.Cmd) == 0 {
+		return nil
+	}
+	return slicez.Concat(r.Docker.Cmd, r.RestoreParams.Cmd)
+}
+
+func (r Resource) BaseEnv() strslice.StrSlice {
+	if len(r.Docker.Env) == 0 && len(r.RestoreParams.Env) == 0 {
+		return nil
+	}
+
+	return slicez.Concat(r.Docker.Env, r.RestoreParams.Env)
+}
+
+func (r Resource) BaseEntrypoint() strslice.StrSlice {
+	if len(r.Docker.Entrypoint) == 0 && len(r.RestoreParams.Entrypoint) == 0 {
+		return nil
+	}
+	return slicez.Concat(r.Docker.Entrypoint, r.RestoreParams.Entrypoint)
+}
+
+func (r Resource) BaseZfsProperties() map[string]string {
+	return r.zfsPropMap(r.RestoreParams.ZfsProperties)
+}
+
+func (r Resource) CloneCmd() strslice.StrSlice {
+	if len(r.Docker.Cmd) == 0 && len(r.CloneParams.Cmd) == 0 {
+		return nil
+	}
+	return slicez.Concat(r.Docker.Cmd, r.CloneParams.Cmd)
+}
+
+func (r Resource) CloneEnv() strslice.StrSlice {
+	if len(r.Docker.Env) == 0 && len(r.CloneParams.Env) == 0 {
+		return nil
+	}
+
+	return slicez.Concat(r.Docker.Env, r.CloneParams.Env)
+}
+
+func (r Resource) CloneEntrypoint() strslice.StrSlice {
+	if len(r.Docker.Entrypoint) == 0 && len(r.CloneParams.Entrypoint) == 0 {
+		return nil
+	}
+	return slicez.Concat(r.Docker.Entrypoint, r.CloneParams.Entrypoint)
+}
+
+func (r Resource) CloneZfsProperties() map[string]string {
+	return r.zfsPropMap(r.CloneParams.ZfsProperties)
+}
+
+func (r Resource) zfsPropMap(config []string) map[string]string {
+	if len(config) == 0 {
+		return nil
+	}
+	zpm := make(map[string]string, len(config))
+	for _, p := range config {
+		kv := strings.Split(p, "=")
+		if len(kv) != 2 {
+			fmt.Printf("'%s' isn't a valid ZFS property/value combination (resource: %s)\n", p, r.Name)
+			continue
+		}
+		zpm[kv[0]] = kv[1]
+	}
+
+	return zpm
 }

--- a/internal/utils/rand.go
+++ b/internal/utils/rand.go
@@ -2,12 +2,7 @@ package utils
 
 import (
 	"math/rand"
-	"time"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 


### PR DESCRIPTION
Add support to set ZFS properties and container command line parameters for base and clones

This commit also includes:
* Fixes a minor command line bug
* Removes usage of some deprecated structs
* Adds missing error handling/corrects wrong error handling
* Fixes a few lint/vet issues