### PR TITLE
Add k8s zdap-proxy config option to destroy clone on stop

### DIFF
--- a/cmd/zdap-proxyd/config.go
+++ b/cmd/zdap-proxyd/config.go
@@ -16,6 +16,7 @@ type conf struct {
 	ResourceFilter string   `env:"ZDAP_RESOURCE_FILTER"`
 	Servers        []string `env:"ZDAP_SERVERS"`
 	ResetAtHhMm    string   `env:"ZDAP_RESET_AT_HH_MM"`
+	DestroyOnStop  bool     `env:"ZDAP_DESTROY_ON_STOP"`
 }
 
 var (

--- a/cmd/zdap-proxyd/k8s.go
+++ b/cmd/zdap-proxyd/k8s.go
@@ -63,6 +63,10 @@ func (p *k8sp) Start(ctx context.Context) {
 }
 
 func (p *k8sp) Stop() {
+	cfg := Config()
+	if cfg.DestroyOnStop && p.clone != nil {
+		p.destroyClone(p.clone)
+	}
 	if p.proxy != nil {
 		p.proxy.Stop()
 	}


### PR DESCRIPTION
Since some of us have started using a minikube cluster for local development, we need the functionality of reseting our local DB frequently. Add this option so that a new clone can be acquired easily instead of having to wait for the reset to trigger.