### PR TITLE
internal control http API on k8s zdap-proxy

### DIFF
--- a/cmd/zdap-proxyd/config.go
+++ b/cmd/zdap-proxyd/config.go
@@ -17,6 +17,7 @@ type conf struct {
 	Servers        []string `env:"ZDAP_SERVERS"`
 	ResetAtHhMm    string   `env:"ZDAP_RESET_AT_HH_MM"`
 	DestroyOnStop  bool     `env:"ZDAP_DESTROY_ON_STOP"`
+	InternalPort   int      `env:"ZDAP_PROXY_INTERNAL_PORT" envDefault:"8080"`
 }
 
 var (

--- a/cmd/zdap-proxyd/k8s.go
+++ b/cmd/zdap-proxyd/k8s.go
@@ -275,10 +275,10 @@ func (p *k8sp) setupControlServer(ctx context.Context) {
 	p.wg.Add(1)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /clone/reset", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("Received HTTP clone reset command")
+	mux.HandleFunc("POST /clones/reset", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Received HTTP /clones/reset command - resetting clone")
 		p.reset()
-		w.Write([]byte("Clone reset successful\n"))
+		w.Write([]byte("Clone reset successfuly\n"))
 	})
 
 	p.controlServer = &http.Server{

--- a/cmd/zdap-proxyd/k8s.go
+++ b/cmd/zdap-proxyd/k8s.go
@@ -17,8 +17,11 @@ import (
 )
 
 type k8sp struct {
-	proxy *TCPProxy
-	clone *zdap.PublicClone
+	proxy         *TCPProxy
+	clone         *zdap.PublicClone
+	controlServer *http.Server
+	done          chan struct{}
+	wg            sync.WaitGroup
 }
 
 func useK8sProxy() bool {
@@ -60,6 +63,8 @@ func (p *k8sp) Start(ctx context.Context) {
 	if cfg.ResetAtHhMm != "" {
 		p.setupResetTimer(ctx, cfg.ResetAtHhMm)
 	}
+
+	p.setupControlServer(ctx)
 }
 
 func (p *k8sp) Stop() {
@@ -70,6 +75,10 @@ func (p *k8sp) Stop() {
 	if p.proxy != nil {
 		p.proxy.Stop()
 	}
+	if p.done != nil {
+		close(p.done)
+	}
+	p.wg.Wait()
 }
 
 func (p *k8sp) attachNewClone() *zdap.PublicClone {
@@ -257,6 +266,47 @@ func (p *k8sp) setupResetTimer(ctx context.Context, atTimeStr string) {
 					p.reset()
 				}
 			}
+		}
+	}()
+}
+
+func (p *k8sp) setupControlServer(ctx context.Context) {
+	p.done = make(chan struct{})
+	p.wg.Add(1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /clone/reset", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Received HTTP clone reset command")
+		p.reset()
+		w.Write([]byte("Clone reset successful\n"))
+	})
+
+	p.controlServer = &http.Server{
+		Addr:    fmt.Sprintf(":%d", Config().InternalPort),
+		Handler: mux,
+	}
+
+	go func() {
+		log.Printf("Starting HTTP control server on port %d", Config().InternalPort)
+		if err := p.controlServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("HTTP server error: %v", err)
+		}
+	}()
+
+	go func() {
+		defer p.wg.Done()
+		select {
+		case <-ctx.Done():
+			log.Printf("Context cancelled, shutting down HTTP control server...")
+		case <-p.done:
+			log.Printf("Done signal received, shutting down HTTP control server...")
+		}
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := p.controlServer.Shutdown(shutdownCtx); err != nil {
+			log.Printf("Error shutting down HTTP server: %v", err)
 		}
 	}()
 }

--- a/cmd/zdap-proxyd/k8s.go
+++ b/cmd/zdap-proxyd/k8s.go
@@ -20,7 +20,6 @@ type k8sp struct {
 	proxy         *TCPProxy
 	clone         *zdap.PublicClone
 	controlServer *http.Server
-	done          chan struct{}
 	wg            sync.WaitGroup
 }
 
@@ -74,9 +73,6 @@ func (p *k8sp) Stop() {
 	}
 	if p.proxy != nil {
 		p.proxy.Stop()
-	}
-	if p.done != nil {
-		close(p.done)
 	}
 	p.wg.Wait()
 }
@@ -271,9 +267,6 @@ func (p *k8sp) setupResetTimer(ctx context.Context, atTimeStr string) {
 }
 
 func (p *k8sp) setupControlServer(ctx context.Context) {
-	p.done = make(chan struct{})
-	p.wg.Add(1)
-
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /clones/reset", func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Received HTTP /clones/reset command - resetting clone")
@@ -293,16 +286,13 @@ func (p *k8sp) setupControlServer(ctx context.Context) {
 		}
 	}()
 
+	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
-		select {
-		case <-ctx.Done():
-			log.Printf("Context cancelled, shutting down HTTP control server...")
-		case <-p.done:
-			log.Printf("Done signal received, shutting down HTTP control server...")
-		}
+		<-ctx.Done()
+		log.Printf("Context cancelled, shutting down HTTP control server...")
 
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 
 		if err := p.controlServer.Shutdown(shutdownCtx); err != nil {

--- a/cmd/zdap-proxyd/zdap-proxyd.go
+++ b/cmd/zdap-proxyd/zdap-proxyd.go
@@ -15,7 +15,7 @@ func check(err error) {
 
 func main() {
 	log.Println("Initializing proxy...")
-	appCtx := context.Background()
+	appCtx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	var proxy interface {
 		Start(context.Context)
@@ -29,11 +29,9 @@ func main() {
 	}
 
 	proxy.Start(appCtx)
-
 	log.Println("Proxy started")
 
-	ctx, cancel := signal.NotifyContext(appCtx, syscall.SIGINT, syscall.SIGTERM)
-	<-ctx.Done()
+	<-appCtx.Done()
 	cancel()
 
 	log.Println("Shutting down proxy")


### PR DESCRIPTION
Since the usage of a local minikube cluster has become our primary dev environment, we need more control over when we get new clones. This is an attempt to remedy that.